### PR TITLE
Make this package more easily usable from Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # do-not-track
 
-Accessing the user's preferences in terms of tracking can be slightly complicated. This module simplifies that.
+Accessing the user's preferences in terms of tracking can be slightly
+complicated. This module simplifies that.
+
+[Read the spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT)
 
 ## Install
 
@@ -13,14 +16,33 @@ Browser:
 ```javascript
 import doNotTrack from 'donottrack';
 
-// Returns true if the user agrees to being tracked, false otherwise.
-const mayTrack = doNotTrack(/* default, if preferences are not set. */ true);
+// Returns true if the user does not want to be tracked, false otherwise,
+// tracking allowed if nothing specified.
+const dnt = doNotTrack();
 ```
 
-Node:
+```javascript
+// Returns true if the user does not want to be tracked, false otherwise,
+// NO TRACKING allowed if nothing specified.
+const dnt = doNotTrack(true);
+```
+
+Node.js:
 
 ```javascript
 import doNotTrack from 'donottrack';
 
-const mayTrack = doNotTrack(req.header('DNT'), true);
+// Or alternative CommonJS import
+//const donottrack = require('donottrack').default;
+
+// Returns true if the user does not want to be tracked, false otherwise,
+// tracking allowed if nothing specified.
+const dnt = doNotTrack(req.headers);
 ```
+
+```javascript
+// Returns true if the user does not want to be tracked, false otherwise,
+// NO TRACKING allowed if nothing specified.
+const dnt = doNotTrack(req.headers, true);
+```
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,32 @@
-
 /**
- * Returns true if the user agrees to being tracked, false if not, def if unspecified.
+ * Returns true if the user does not want to be tracked, false otherwise, def if unspecified.
  *
- * @param {!string} [dntHeader] The DNT header.
- * @param {!boolean} [def = false] The value to return if doNotTrack is unspecified.
- * @returns {!boolean} The user agrees to being tracked.
+ * @param {Object} [headers] The request headers, when used on the server-side.
+ * @param {boolean} [def=false] The value to return if doNotTrack is unspecified.
+ * @returns {boolean} The user agrees to being tracked.
  */
-export default function mayTrack(dntHeader, def = false) {
-
-  // backward compatibility
-  if (typeof dntHeader === 'boolean') {
-    def = dntHeader;
+export default function doNotTrack(headers, def = false) {
+  // Dealing with optional headers parameter
+  if (arguments.length == 1 && typeof arguments[0] == 'boolean') {
+    headers = undefined;
+    def = arguments[0];
   }
 
-  if (typeof dntHeader !== 'string') {
-    dntHeader = getBrowserDnt();
+  var dnt;
+  if (headers !== undefined) {
+    // In Node.js headers keys are lowercased. Values are not modified
+    // cf. https://nodejs.org/api/http.html#http_http
+    dnt = headers.dnt;
+  } else {
+    dnt = getBrowserDnt();
   }
 
-  if (dntHeader != null) {
-    if (dntHeader.charAt(0) === '1' || dntHeader === 'yes') {
+  if (dnt) {
+    if (dnt.charAt(0) === '1' || dnt === 'yes') {
       return true;
     }
 
-    if (dntHeader.charAt(0) === '0' || dntHeader === 'no') {
+    if (dnt.charAt(0) === '0' || dnt === 'no') {
       return false;
     }
   }
@@ -37,4 +41,3 @@ export function getBrowserDnt() {
 
   return window.doNotTrack || window.navigator.doNotTrack || window.navigator.msDoNotTrack;
 }
-

--- a/tests/browser.test.js
+++ b/tests/browser.test.js
@@ -4,10 +4,22 @@ const dnt = require('../lib/').default;
 // TODO transpile.
 // TODO run in real browsers.
 
-describe('do not track', () => {
+describe('do not track used from browsers', () => {
   beforeEach(() => {
     global.window = {};
     window.navigator = {};
+  });
+
+  afterEach(() => {
+    delete global.window;
+  });
+
+  it('should return false when nothing set', () => {
+    should(dnt()).equal(false);
+  });
+
+  it('should return true when nothing set, with default true', () => {
+    should(dnt(true)).equal(true);
   });
 
   it('should return false for firefox when disabled', () => {
@@ -52,11 +64,4 @@ describe('do not track', () => {
     should(dnt()).equal(true);
   });
 
-  it('should return true for HTTP Requests when enabled', () => {
-    should(dnt('1')).equal(true);
-  });
-
-  it('should return false for HTTP Requests when enabled', () => {
-    should(dnt('0')).equal(false);
-  });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,38 @@
+const should = require('should');
+const dnt = require('../lib/').default;
+
+describe('do not track used from the server', () => {
+
+  it('should return true for HTTP Requests when enabled', () => {
+    // In Node.js headers keys are lowercased. Values are not modified
+    // cf. https://nodejs.org/api/http.html#http_http
+    const headers = {dnt: '1'};
+    should(dnt(headers)).equal(true);
+  });
+
+  it('should return true for HTTP Requests when enabled, with default true', () => {
+    const headers = {dnt: '1'};
+    should(dnt(headers, true)).equal(true);
+  });
+
+  it('should return false for HTTP Requests when disabled', () => {
+    const headers = {dnt: '0'};
+    should(dnt(headers)).equal(false);
+  });
+
+  it('should return false for HTTP Requests when disabled, with default true', () => {
+    const headers = {dnt: '0'};
+    should(dnt(headers, true)).equal(false);
+  });
+
+  it('should return false for HTTP Requests when not set', () => {
+    const headers = {};
+    should(dnt(headers)).equal(false);
+  });
+
+  it('should return true for HTTP Requests when not set, with default true', () => {
+    const headers = {};
+    should(dnt(headers, true)).equal(true);
+  });
+
+});


### PR DESCRIPTION
This brings an API change and thus requires a major upgrade in version.

This PR was inspired by #3 and supersedes it.

The README of the modified version can easily be read [here](https://github.com/madarche/do-not-track/tree/fix-for-node.js).

I've published a scoped package [@madarche/donottrack@2.0.0](https://www.npmjs.com/package/@madarche/donottrack) for those interested.